### PR TITLE
Add variant of unfold that uses the inner monad

### DIFF
--- a/library/ListT.hs
+++ b/library/ListT.hs
@@ -293,6 +293,18 @@ unfold f s =
   maybe mzero (\(h, t) -> cons h (unfold f t)) (f s)
 
 -- |
+-- Construct by unfolding a monadic data structure
+--
+-- This is the most memory-efficient way to construct a ListT where
+-- the length depends on the inner monad.
+{-# INLINABLE unfoldM #-}
+unfoldM :: (Monad m) => (b -> m (Maybe (a, b))) -> b -> ListT m a
+unfoldM f = go where
+  go s = ListT $ f s >>= \case
+    Nothing -> return Nothing
+    Just (a,r) -> return (Just (a, go r))
+
+-- |
 -- Produce an infinite stream.
 {-# INLINABLE repeat #-}
 repeat :: (MonadCons m) => a -> m a

--- a/library/ListT.hs
+++ b/library/ListT.hs
@@ -19,6 +19,7 @@ module ListT
   fromFoldable,
   fromMVar,
   unfold,
+  unfoldM,
   repeat,
   -- * Transformation utilities
   -- | 


### PR DESCRIPTION
Slightly contrived example usage:

    confirmRetry = return () <|> unfoldM (\_ -> do
      liftIO $ putStrLn "Try again? (y/n)"
      l <- liftIO getLine
      case map toLower l of
        ('y':_) -> return (Just ((),()))
        _ -> return Nothing
     ) ()
