### PR TITLE
avoid compilation problems introduced in d06b4ac

### DIFF
--- a/library/ListT.hs
+++ b/library/ListT.hs
@@ -116,7 +116,7 @@ instance MonadIO m => MonadIO (ListT m) where
 
 instance MFunctor ListT where
   hoist f =
-    ListT . f . (fmap . fmap) (id *** hoist f) . unListT
+    ListT . f . (liftM . fmap) (id *** hoist f) . unListT
 
 instance MMonad ListT where
   embed f (ListT m) =


### PR DESCRIPTION
The refactoring in d06b4ac caused a [compilation error] (https://travis-ci.org/nikita-volkov/list-t/jobs/108771718) because apparently the new code tries to apply `fmap` on something which is a Monad but not a Functor. I think something like that can happen since [the Functor-Applicative-Monad proposal was realized in GHC](https://wiki.haskell.org/Functor-Applicative-Monad_Proposal). My proposal fixes this problem by using `liftM` instead of `fmap`.