### PR TITLE
Make fmap and hoist a bit stricter

### DIFF
--- a/library/ListT/Prelude.hs
+++ b/library/ListT/Prelude.hs
@@ -5,7 +5,6 @@ module ListT.Prelude
 where
 
 import Control.Applicative as Exports
-import Control.Arrow as Exports
 import Control.Category as Exports
 import Control.Concurrent as Exports
 import Control.Exception as Exports


### PR DESCRIPTION
Previously, `fmap` and `hoist` would produce lazy pairs, thanks
to the laziness of `Control.Arrow.***`. That laziness isn't
desirable; the most useful laziness is in the pair components
themselves. Use a custom copy of `***` that doesn't do that.