### PR TITLE
Add MonadReader and MonadState instances

### DIFF
--- a/library/ListT.hs
+++ b/library/ListT.hs
@@ -197,6 +197,18 @@ instance MonadError e m => MonadError e (ListT m) where
   throwError = ListT . throwError
   catchError m handler = ListT $ catchError (uncons m) $ uncons . handler
 
+instance MonadReader e m => MonadReader e (ListT m) where
+  ask = lift ask
+  reader = lift . reader
+  local r = go
+    where
+      go (ListT m) = ListT $ local r (fmap (fmap (secondPair' go)) m)
+
+instance MonadState e m => MonadState e (ListT m) where
+  get = lift get
+  put = lift . put
+  state = lift . state
+
 instance Monad m => MonadLogic (ListT m) where
   msplit (ListT m) = lift m
 

--- a/library/ListT/Prelude.hs
+++ b/library/ListT/Prelude.hs
@@ -2,6 +2,7 @@ module ListT.Prelude
 ( 
   module Exports,
   bimapPair',
+  secondPair',
 )
 where
 
@@ -18,11 +19,12 @@ import Control.Monad.Fix as Exports hiding (fix)
 import Control.Monad.IO.Class as Exports
 import Control.Monad.Logic.Class as Exports
 import Control.Monad.Morph as Exports hiding (MonadTrans(..))
+import Control.Monad.Reader.Class as Exports
+import Control.Monad.State.Class as Exports
 import Control.Monad.ST as Exports
 import Control.Monad.Trans.Class as Exports
 import Control.Monad.Trans.Control as Exports hiding (embed, embed_)
 import Control.Monad.Trans.Maybe as Exports hiding (liftCatch, liftCallCC)
-import Control.Monad.Trans.Reader as Exports hiding (liftCatch, liftCallCC)
 import Control.Monad.Zip as Exports
 import Data.Bits as Exports
 import Data.Bool as Exports
@@ -84,3 +86,9 @@ import Unsafe.Coerce as Exports
 -- There's no benefit to producing lazy pairs here.
 bimapPair' :: (a -> b) -> (c -> d) -> (a, c) -> (b, d)
 bimapPair' f g = \(a,c) -> (f a, g c)
+
+-- |
+-- A slightly stricter version of Data.Bifunctor.second
+-- that doesn't produce gratuitous lazy pairs.
+secondPair' :: (b -> c) -> (a, b) -> (a, c)
+secondPair' f = \(a,b) -> (a, f b)


### PR DESCRIPTION
* I've pretty well convinced myself that this obeys the `MonadReader` laws [proposed by Heinrich Apfelmus](https://github.com/haskell/mtl/issues/5#issuecomment-29734233) and the ones [proposed by Li-yao Xia](https://github.com/haskell/mtl/issues/5#issuecomment-349839199), so I think it should be added.

* The `MonadState` instance is trivial.

Closes #23.