### PR TITLE
should be strict list's head

### DIFF
--- a/library/ListT.hs
+++ b/library/ListT.hs
@@ -407,7 +407,7 @@ splitAt =
 -- |
 -- Prepend an element.
 cons :: Monad m => a -> ListT m a -> ListT m a
-cons h t =
+cons !h t =
   ListT $ return (Just (h, t))
 
 -- |


### PR DESCRIPTION
Making the head of the stream lazy makes user to watch out the laziness/strictness of the stream. It does not make sense, 'cause in such way we may just use lists. For an instance, the following example will explode on a large input without force in line 41:

```
module Main where

import Data.ByteArray qualified as BA
import Control.Monad
import Control.DeepSeq
import Control.Monad.IO.Class
import Data.Function
import Data.ByteString (ByteString)
import Data.ByteString qualified as B
import Data.ByteString.Short qualified as SB
import ListT qualified as L
import ListT (ListT(..))
import System.IO
import Crypto.Hash


duHash :: ByteString -> SB.ShortByteString
duHash =  SB.toShort . BA.convert . hash @_ @SHA256

readBS :: MonadIO m => Int -> Handle -> (ListT m ByteString -> m a) -> m a
readBS size h consumer = consumer $ fix $ \next -> do
  chunk <- liftIO $ B.hGet h size
  if B.null chunk then do
    mzero
  else
    L.cons chunk next


unfoldHandle :: MonadIO m => Int -> Handle -> m (Maybe (ByteString, Handle))
unfoldHandle size h = do
  chunk <- liftIO $ B.hGet h size
  if not (B.null chunk) then
    pure (Just (chunk, h) )
  else
    pure Nothing


main :: IO ()
main = do
  -- some <- readBS (265*1024) stdin (L.toList . fmap (force . hashObject))
  some <- L.toList  $ L.traverse ( pure . force . duHash )  $ L.unfoldM (unfoldHandle (256*1024)) stdin
    -- readBS (265*1024) stdin (L.toList . fmap (force . hashObject))
  print (length some)

```

with the suggested patch, it will work without calling the force, like an ordinary stream.  Streaming, for an instance has the type

![image](https://user-images.githubusercontent.com/72333/211180824-2f28d230-bb6c-49f5-acfb-6d1451bcf220.png)

so basically this is an expected behavior from streaming.


