### PR TITLE
Make it build with ghc-9.8

### DIFF
--- a/library/ListT/Prelude.hs
+++ b/library/ListT/Prelude.hs
@@ -36,7 +36,7 @@ import Data.Either as Exports
 import Data.Fixed as Exports
 import Data.Foldable as Exports
 import Data.Function as Exports hiding (id, (.))
-import Data.Functor as Exports
+import Data.Functor as Exports hiding (unzip)
 import Data.Functor.Classes as Exports
 import Data.IORef as Exports
 import Data.Int as Exports
@@ -78,7 +78,7 @@ import Text.ParserCombinators.ReadPrec as Exports (ReadPrec, readP_to_Prec, read
 import Text.Printf as Exports (hPrintf, printf)
 import Text.Read as Exports (Read (..), readEither, readMaybe)
 import Unsafe.Coerce as Exports
-import Prelude as Exports hiding (all, and, any, concat, concatMap, elem, fail, foldl, foldl1, foldr, foldr1, id, mapM, mapM_, maximum, minimum, notElem, or, product, sequence, sequence_, sum, (.))
+import Prelude as Exports hiding (all, and, any, concat, concatMap, elem, fail, foldl, foldl1, foldr, foldr1, id, mapM, mapM_, maximum, minimum, notElem, or, product, sequence, sequence_, sum, (.), unzip)
 
 -- |
 -- A slightly stricter version of Data.Bifunctor.bimap.

--- a/list-t.cabal
+++ b/list-t.cabal
@@ -67,7 +67,7 @@ library
   other-modules:   ListT.Prelude
   build-depends:
     , base               >=4.11 && <5
-    , foldl              >=1    && <2
+    , foldl              >=1.2  && <2
     , logict             >=0.7  && <0.9
     , mmorph             >=1    && <2
     , monad-control      >=0.3  && <2


### PR DESCRIPTION
I also needed the following in a `cabal.project` file:
```cabal
packages:
    .

if impl(ghc >= 9.8)
  constraints:
    , primitive >= 0.5
    , text >= 2.1

  allow-newer:
    , *:base
    , *:bytestring
    , *:deepseq
    , *:text
```